### PR TITLE
Extend sidekick

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ node_modules/*
 
 helix-importer-ui
 .DS_Store
+
+.idea

--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -1,6 +1,6 @@
 {
   "project": "Siemens Press goes Franklin",
-  "pushDown": true,
+  "devMode": true,
   "plugins": [
     {
       "id": "tools",

--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -1,0 +1,24 @@
+{
+  "project": "Siemens Press goes Franklin",
+  "pushDown": true,
+  "plugins": [
+    {
+      "id": "tools",
+      "title": "Tools",
+      "isContainer": true,
+      "environments": [
+        "edit",
+        "preview"
+      ]
+    },
+    {
+      "id": "assets",
+      "title": "Assets",
+      "containerId": "tools",
+      "environments": [
+        "edit"
+      ],
+      "url": "https://assets.new.siemens.com/content/siemens/assets/ui/en/search.html#/search/all/*"
+    }
+  ]
+}


### PR DESCRIPTION
Added a Sidekick extension to test how a simple asset integration could look like.

Test URLs:
- Before: https://main--siemens-press--groundfoghub.hlx.page/enlit-europe-2022
- After: https://extend-sidekick--siemens-press--groundfoghub.hlx.live/enlit-europe-2022
