### PR TITLE
Removed the tools container from the preview mode

### DIFF
--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -7,8 +7,7 @@
       "title": "Tools",
       "isContainer": true,
       "environments": [
-        "edit",
-        "preview"
+        "edit"
       ]
     },
     {


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--siemens-press--groundfoghub.hlx.page/enlit-europe-2022
- After: https://extend-sidekick--siemens-press--groundfoghub.hlx.live/enlit-europe-2022
