### PR TITLE
Added CDN host name to the Sidekick configuration

### DIFF
--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -1,5 +1,6 @@
 {
   "project": "Siemens Press goes Franklin",
+  "host": "press.siemens.groundfog.cloud",
   "devMode": true,
   "plugins": [
     {


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://update-host-information--siemens-press--groundfoghub.hlx.page/global/en/enlit-europe-2022
- After: https://main--siemens-press--groundfoghub.hlx.live/global/en/enlit-europe-2022
