### PR TITLE
Font family fallback

### DIFF
--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -88,7 +88,7 @@
 
 .newHomeHeader__links .newHomeHeader__link {
   font-size: 1.125rem;
-  font-family: Siemens Sans Roman,arial,sans-serif;
+  font-family: 'Siemens Sans Roman', 'Siemens Sans Roman Fallback';
   line-height: 1.5555555556;
   color: var(--theme-color-1);
   font-weight: 400;
@@ -161,7 +161,7 @@
 
 .newHomeHeader__firstNaviItem {
   font-size: 1.125rem;
-  font-family: Siemens Sans Black,arial,sans-serif;
+  font-family: 'Siemens Sans Black', 'Siemens Sans Black Fallback';
   line-height: 1.5555555556;
   color: var(--theme-color-1);
   font-weight: 400;
@@ -261,7 +261,7 @@
 
 .newHomeHeader__regionSelector {
   font-size: 1.125rem;
-  font-family: Siemens Sans Black,arial,sans-serif;
+  font-family: 'Siemens Sans Black', 'Siemens Sans Black Fallback';
   line-height: 1.5555555556;
   color: var(--theme-color-1);
   font-weight: 400;

--- a/blocks/stage/stage.css
+++ b/blocks/stage/stage.css
@@ -250,7 +250,7 @@
   
   .newHomeStage__topics .newHomeTopic__topicList {
     font-size: 1.125rem;
-    font-family: Siemens Sans Black,arial,sans-serif;
+    font-family: 'Siemens Sans Black', 'Siemens Sans Black Fallback';
     line-height: 1.2222222222;
     color: var(--theme-color-1);
     font-weight: 400;
@@ -260,7 +260,7 @@
   
   .newHomeStage__header {
     font-size: 2.5rem;
-    font-family: Siemens Sans Black,arial,sans-serif;
+    font-family: 'Siemens Sans Black', 'Siemens Sans Black Fallback';
     line-height: 1.2;
     color: var(--theme-color-1);
     font-weight: 400;
@@ -278,7 +278,7 @@
   @media (min-width: 600px) {
     .newHomeStage__header {
         font-size:3rem;
-        font-family: Siemens Sans Black,arial,sans-serif;
+        font-family: 'Siemens Sans Black', 'Siemens Sans Black Fallback';
         line-height: 1.1666666667
     }
   }
@@ -286,7 +286,7 @@
   @media (min-width: 1440px) {
     .newHomeStage__header {
         font-size:3.75rem;
-        font-family: Siemens Sans Black,arial,sans-serif;
+        font-family: 'Siemens Sans Black', 'Siemens Sans Black Fallback';
         line-height: 1.2
     }
   }
@@ -314,7 +314,7 @@
   
   .newHomeStage__text {
     font-size: 1.125rem;
-    font-family: Siemens Sans Roman,arial,sans-serif;
+    font-family: 'Siemens Sans Roman', 'Siemens Sans Roman Fallback';
     line-height: 1.5555555556;
     color: var(--theme-color-1);
     font-weight: 400;
@@ -333,12 +333,14 @@
     overflow: hidden
   }
   
-  .newHomeStage__text i {
-    font-family: Siemens Sans Prof Italic,arial,sans-serif
+  .newHomeStage__text i,
+  .newHomeStage__text em {
+    font-family: 'Siemens Sans Prof Italic', 'Siemens Sans Prof Italic Fallback'
   }
   
-  .newHomeStage__text b,.newHomeStage__text strong {
-    font-family: Siemens Sans Prof Bold,arial,sans-serif
+  .newHomeStage__text b,
+  .newHomeStage__text strong {
+    font-family: 'Siemens Sans Prof Bold', 'Siemens Sans Prof Bold Fallback'
   }
   
   .newHomeStage__text p+p {
@@ -432,7 +434,7 @@
   
   .newHomeStage__button.newHomeButton.newHomeButton--primary {
     font-size: 1.125rem;
-    font-family: Siemens Sans Black,arial,sans-serif;
+    font-family: 'Siemens Sans Black', 'Siemens Sans Black Fallback';
     line-height: 1.5555555556;
     color: var(--theme-color-1);
     font-weight: 400;
@@ -559,7 +561,7 @@
   @media (min-width: 600px) {
     .newHomeStage.newHomeStage--imageRight .newHomeStage__header,.newHomeStage.newHomeStage--imageLeft .newHomeStage__header {
         font-size:2rem;
-        font-family: Siemens Sans Black,arial,sans-serif;
+        font-family: 'Siemens Sans Black', 'Siemens Sans Black Fallback';
         line-height: 1.25;
         color: var(--theme-color-1);
         font-weight: 400;
@@ -570,7 +572,7 @@
   @media (min-width: 600px) and (min-width: 600px) {
     .newHomeStage.newHomeStage--imageRight .newHomeStage__header,.newHomeStage.newHomeStage--imageLeft .newHomeStage__header {
         font-size:2.25rem;
-        font-family: Siemens Sans Black,arial,sans-serif;
+        font-family: 'Siemens Sans Black', 'Siemens Sans Black Fallback';
         line-height: 1.3333333333
     }
   }
@@ -578,14 +580,14 @@
   @media (min-width: 600px) and (min-width: 1440px) {
     .newHomeStage.newHomeStage--imageRight .newHomeStage__header,.newHomeStage.newHomeStage--imageLeft .newHomeStage__header {
         font-size:2.5rem;
-        font-family: Siemens Sans Black,arial,sans-serif;
+        font-family: 'Siemens Sans Black', 'Siemens Sans Black Fallback';
         line-height: 1.3
     }
   }
   
   @media (min-width: 600px) {
     .newHomeStage.newHomeStage--imageRight .newHomeStage__header:first-line,.newHomeStage.newHomeStage--imageLeft .newHomeStage__header:first-line {
-        font-family:Siemens Sans Black,arial,sans-serif
+        font-family:'Siemens Sans Black', 'Siemens Sans Black Fallback'
     }
   }
   

--- a/styles/lazy-styles.css
+++ b/styles/lazy-styles.css
@@ -3,23 +3,23 @@
 /* stylelint-disable */
 
 /* default.page */
-
-  @font-face {
-    font-family: Siemens Sans Black;
-    src: url(/fonts/woff2/SiemensSans_Prof_Black.woff2) format("woff2");
+@font-face {
+    font-family: 'Siemens Sans Black';
+    font-style: normal;
     font-weight: 400;
-    font-display: swap
+    font-display: swap;
+    src: url('/fonts/woff2/SiemensSans_Prof_Black.woff2') format('woff2');
 }
 
 @font-face {
-    font-family: Siemens Sans Black;
+    font-family: 'Siemens Sans Black';
     font-style: italic;
     font-display: swap;
     src: url(/fonts/woff2/SiemensSans_Prof_BlackItalic.woff2) format("woff2")
 }
 
 @font-face {
-    font-family: Siemens Sans Prof Bold;
+    font-family: 'Siemens Sans Prof Bold';
     font-style: bold;
     font-weight: 700;
     font-display: swap;
@@ -27,7 +27,7 @@
 }
 
 @font-face {
-    font-family: Siemens Sans Prof Bold Italic;
+    font-family: 'Siemens Sans Prof Bold Italic';
     font-style: italic;
     font-weight: 700;
     font-display: swap;
@@ -35,14 +35,14 @@
 }
 
 @font-face {
-    font-family: Siemens Sans Prof Italic;
+    font-family: 'Siemens Sans Prof Italic';
     font-style: italic;
     font-display: swap;
     src: url(/fonts/woff2/SiemensSans_Prof_Italic.woff2) format("woff2")
 }
 
 @font-face {
-    font-family: Siemens Sans Roman;
+    font-family: 'Siemens Sans Roman';
     font-style: italic;
     font-display: swap;
     src: url(/fonts/woff2/SiemensSans_Prof_Roman.woff2) format("woff2")

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -10,6 +10,50 @@
  * governing permissions and limitations under the License.
  */
 
+ @font-face {
+  font-family: 'Siemens Sans Black Fallback';
+  font-style: normal;
+  font-weight: 400;
+  src: local('Arial');
+  ascent-override: 85.98%;
+  descent-override: 21.52%;
+  line-gap-override: 0.00%;
+  size-adjust: 111.65%;
+}
+
+@font-face {
+  font-family: 'Siemens Sans Roman Fallback';
+  font-style: normal;
+  font-weight: 400;
+  src: local('Arial');
+  ascent-override: 96.65%;
+  descent-override: 24.19%;
+  line-gap-override: 0.00%;
+  size-adjust: 99.33%;
+}
+
+@font-face {
+  font-family: 'Siemens Sans Prof Bold Fallback';
+  font-style: bold;
+  font-weight: 700;
+  src: local('Arial Bold');
+  ascent-override: 97.96%;
+  descent-override: 24.52%;
+  line-gap-override: 0.00%;
+  size-adjust: 97.99%;
+}
+
+@font-face {
+  font-family: 'Siemens Sans Prof Italic Fallback';
+  font-style: italic;
+  font-weight: 400;
+  src: local('Arial Italic');
+  ascent-override: 95.86%;
+  descent-override: 23.99%;
+  line-gap-override: 0.00%;
+  size-adjust: 100.14%;
+}
+
  :root {
   /* colors */
   --link-color: #035fe6;
@@ -20,9 +64,10 @@
   --text-color: #000;
 
   /* fonts */
-  --body-font-family: 'helvetica neue', helvetica, ubuntu, roboto, noto, sans-serif;
+
+  /* --body-font-family: 'helvetica neue', helvetica, ubuntu, roboto, noto, sans-serif;
   --heading-font-family: var(--body-font-family);
-  --fixed-font-family: 'Roboto Mono', menlo, consolas, 'Liberation Mono', monospace;
+  --fixed-font-family: 'Roboto Mono', menlo, consolas, 'Liberation Mono', monospace; */
 
   /* body sizes */
   --body-font-size-m: 22px;


### PR DESCRIPTION
Introduced new font-family for fallback fonts. Parameters generated using https://github.com/pixel-point/fontpie

Test URLs:
- Before: https://main--siemens-press--groundfoghub.hlx.page/
- After: https://font-family-fallback--siemens-press--groundfoghub.hlx.page/
