### PR TITLE
Introducing new block: fragment

### DIFF
--- a/blocks/fragment/fragment.css
+++ b/blocks/fragment/fragment.css
@@ -1,0 +1,1 @@
+/* Empty file */

--- a/blocks/fragment/fragment.js
+++ b/blocks/fragment/fragment.js
@@ -1,0 +1,45 @@
+/*
+ * Fragment Block
+ * Include content from one Helix page in another.
+ * https://www.hlx.live/developer/block-collection/fragment
+ */
+
+import {
+  decorateMain,
+} from '../../scripts/scripts.js';
+
+import {
+  loadBlocks,
+} from '../../scripts/lib-franklin.js';
+
+/**
+   * Loads a fragment.
+   * @param {string} path The path to the fragment
+   * @returns {HTMLElement} The root element of the fragment
+   */
+async function loadFragment(path) {
+  if (path && path.startsWith('/')) {
+    const resp = await fetch(`${path}.plain.html`);
+    if (resp.ok) {
+      const main = document.createElement('main');
+      main.innerHTML = await resp.text();
+      decorateMain(main);
+      await loadBlocks(main);
+      return main;
+    }
+  }
+  return null;
+}
+
+export default async function decorate(block) {
+  const link = block.querySelector('a');
+  const path = link ? link.getAttribute('href') : block.textContent.trim();
+  const fragment = await loadFragment(path);
+  if (fragment) {
+    const fragmentSection = fragment.querySelector(':scope .section');
+    if (fragmentSection) {
+      block.closest('.section').classList.add(...fragmentSection.classList);
+      block.closest('.fragment-wrapper').replaceWith(...fragmentSection.childNodes);
+    }
+  }
+}


### PR DESCRIPTION
Introducing "Fragment" block, from Adobe repo.

Test URLs:
- Before: https://stage--siemens-press--groundfoghub.hlx.page/global/en/template-press-events
- After: https://fragment-block--siemens-press--groundfoghub.hlx.page/global/en/template-press-events
